### PR TITLE
update eth.sh to v1.8.18

### DIFF
--- a/updates/nodes/eth.sh
+++ b/updates/nodes/eth.sh
@@ -4,12 +4,12 @@ set -e
 echo 'Updating Ethereum. This may take a minute.'
 supervisorctl stop ethereum
 echo 'Downloading...'
-curl -#o /tmp/ethereum.tar.gz https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.17-8bbe7207.tar.gz
+curl -#o /tmp/ethereum.tar.gz https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.18-58632d44.tar.gz
 tar -xzf /tmp/ethereum.tar.gz -C /tmp/
 echo 'Updating...'
 mv /usr/local/bin/geth /usr/local/bin/geth-old
-cp /tmp/geth-linux-amd64-1.8.17-8bbe7207/geth /usr/local/bin/geth
-rm -r /tmp/geth-linux-amd64-1.8.17-8bbe7207
+cp /tmp/geth-linux-amd64-1.8.18-58632d44/geth /usr/local/bin/geth
+rm -r /tmp/geth-linux-amd64-1.8.18-58632d44
 rm /tmp/ethereum.tar.gz
 supervisorctl start ethereum
 echo 'Ethereum is updated.'


### PR DESCRIPTION
Updated text to install geth v1.8.18:
https://github.com/ethereum/go-ethereum/releases/tag/v1.8.18